### PR TITLE
Implement OAuth refresh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV GO111MODULE=on
 
 RUN go mod download
 
-COPY $PWD/* ./
+COPY $PWD/*.go ./
 
 RUN go build -o /bin/monzo_exporter
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Very alpha
 
 - [x] Export metrics from Monzo
 - [x] OAuth token capture
-- [ ] OAuth token refresh
+- [x] OAuth token refresh
 - [ ] OAuth token persistent storage
 
 ## Instructions

--- a/main.go
+++ b/main.go
@@ -71,6 +71,10 @@ func main() {
 		go func() {
 			for _ = range tickerOAuthInterval.C {
 				log.Println("Refreshing OAuth tokens")
+				err := monzoOAuthClient.RefreshAToken()
+				if err != nil {
+					log.Printf("Encountered error refreshing tokens")
+				}
 			}
 		}()
 	} else {

--- a/main.go
+++ b/main.go
@@ -70,16 +70,18 @@ func main() {
 	if *monzoAccessTokens == "" {
 		go func() {
 			for _ = range tickerOAuthInterval.C {
-				log.Println("Refreshing OAuth tokens")
+				log.Println("main: Refreshing OAuth tokens")
 				err := monzoOAuthClient.RefreshAToken()
 				if err != nil {
-					log.Printf("Encountered error refreshing tokens")
+					log.Printf("main: Encountered error refreshing tokens")
 				}
+				log.Println("main: Refreshed OAuth tokens")
 			}
 		}()
 	} else {
-		log.Println("Skipping starting OAuth token refresher")
+		log.Println("main: Skipping starting OAuth token refresher")
 	}
 
+	log.Printf("main: Serving prometheus on :%d", *metricsPort)
 	http.ListenAndServe(fmt.Sprintf(":%d", *metricsPort), promhttp.Handler())
 }

--- a/monzo_api.go
+++ b/monzo_api.go
@@ -113,3 +113,33 @@ func GetBalance(accessToken string, accountID MonzoAccountID) (MonzoBalance, err
 
 	return balance, nil
 }
+
+func RefreshToken(clientId string, clientSecret string, accessToken string, refreshToken string) (MonzoAccessAndRefreshTokens, error) {
+	var returnTokens MonzoAccessAndRefreshTokens
+
+	req := MonzoClient(accessToken)
+	req.Path("/oauth2/token?grant_type=refresh_token")
+	req.AddQuery("grant_type", "refresh_token")
+	req.AddQuery("client_id", clientId)
+	req.AddQuery("client_secret", clientSecret)
+	log.Printf("Requesting: /oauth2/token")
+	resp, err := req.Send()
+
+	if err != nil {
+		log.Printf("Encountered error: /oauth2/token?grant_type=refresh_token => %s", err)
+		return returnTokens, err
+	}
+
+	var authResponse MonzoAuthResponse
+	err = json.Unmarshal(resp.Bytes(), &authResponse)
+
+	if err != nil {
+		log.Printf("Encountered error unmarshalling refresh token response => %s", err)
+		return returnTokens, err
+	}
+
+	returnTokens.AccessToken = authResponse.AccessToken
+	returnTokens.RefreshToken = authResponse.RefreshToken
+
+	return returnTokens, nil
+}

--- a/monzo_api.go
+++ b/monzo_api.go
@@ -25,17 +25,18 @@ func GetUserIdentity(accessToken string) (MonzoCallerIdentity, error) {
 
 	req := MonzoClient(accessToken)
 	req.Path("/ping/whoami")
-	log.Print("Requesting: /ping/whoami")
+	log.Print("GetUserIdentity: Requesting: /ping/whoami")
 	resp, err := req.Send()
 
 	if err != nil {
-		log.Printf("Encountered error: /ping/whoami => %s", err)
+		log.Printf("GetUserIdentity: Encountered error: /ping/whoami => %s", err)
 		return callerID, err
 	}
-	log.Print("Finished: /ping/whoami")
+	log.Println("GetUserIdentity: Finished: /ping/whoami")
 
 	err = json.Unmarshal(resp.Bytes(), &callerID)
 	if err != nil {
+		log.Printf("GetUserIdentity: Encountered error unmarshalling => %s", err)
 		return callerID, err
 	}
 
@@ -47,23 +48,25 @@ func ListAccounts(accessToken string) ([]MonzoAccount, error) {
 
 	req := MonzoClient(accessToken)
 	req.Path("/accounts")
-	log.Print("Requesting: /accounts")
+	log.Print("ListAccounts: Requesting: /accounts")
 	resp, err := req.Send()
 
 	if err != nil {
-		log.Printf("Encountered error: /accounts => %s", err)
+		log.Printf("ListAccounts: Encountered error: /accounts => %s", err)
 		return accounts, err
 	}
-	log.Printf("Finished: /accounts")
+	log.Printf("ListAccounts: Finished: /accounts")
 
 	var accountsResp MonzoAPIListAccountsResponse
 
 	err = json.Unmarshal(resp.Bytes(), &accountsResp)
 	if err != nil {
+		log.Printf("ListAccounts: Encountered error unmarshalling => %s", err)
 		return accounts, err
 	}
 
 	accounts = accountsResp.Accounts
+	log.Printf("ListAccounts: Done")
 	return accounts, nil
 }
 
@@ -72,14 +75,14 @@ func ListPots(accessToken string) ([]MonzoPot, error) {
 
 	req := MonzoClient(accessToken)
 	req.Path("/pots")
-	log.Print("Requesting: /pots")
+	log.Print("ListPots: Requesting: /pots")
 	resp, err := req.Send()
 
 	if err != nil {
-		log.Printf("Encountered error: /pots => %s", err)
+		log.Printf("ListPots: Encountered error: /pots => %s", err)
 		return pots, err
 	}
-	log.Print("Finished: /pots")
+	log.Print("ListPots Finished: /pots")
 
 	var potsResp MonzoAPIListPotsResponse
 
@@ -98,14 +101,14 @@ func GetBalance(accessToken string, accountID MonzoAccountID) (MonzoBalance, err
 	req := MonzoClient(accessToken)
 	req.Path("/balance")
 	req.AddQuery("account_id", string(accountID))
-	log.Printf("Requesting: /balance?account_id=%s", accountID)
+	log.Printf("GetBalance: Requesting: /balance?account_id=%s", accountID)
 	resp, err := req.Send()
 
 	if err != nil {
-		log.Printf("Encountered error: /pots => %s", err)
+		log.Printf("GetBalance: Encountered error: /pots => %s", err)
 		return balance, err
 	}
-	log.Printf("Finished: /balance?account_id=%s", accountID)
+	log.Printf("GetBalance: Finished: /balance?account_id=%s", accountID)
 
 	err = json.Unmarshal(resp.Bytes(), &balance)
 	if err != nil {
@@ -123,11 +126,14 @@ func RefreshToken(clientId string, clientSecret string, accessToken string, refr
 	req.AddQuery("grant_type", "refresh_token")
 	req.AddQuery("client_id", clientId)
 	req.AddQuery("client_secret", clientSecret)
-	log.Printf("Requesting: /oauth2/token")
+	log.Printf("RefreshToken: Requesting: /oauth2/token")
 	resp, err := req.Send()
 
 	if err != nil {
-		log.Printf("Encountered error: /oauth2/token?grant_type=refresh_token => %s", err)
+		log.Printf(
+			"RefreshToken: Encountered error: /oauth2/token?grant_type=refresh_token => %s",
+			err,
+		)
 		return returnTokens, err
 	}
 
@@ -135,7 +141,10 @@ func RefreshToken(clientId string, clientSecret string, accessToken string, refr
 	err = json.Unmarshal(resp.Bytes(), &authResponse)
 
 	if err != nil {
-		log.Printf("Encountered error unmarshalling refresh token response => %s", err)
+		log.Printf(
+			"RefreshToken: Encountered error unmarshalling refresh token response => %s",
+			err,
+		)
 		return returnTokens, err
 	}
 
@@ -143,6 +152,9 @@ func RefreshToken(clientId string, clientSecret string, accessToken string, refr
 		time.Duration(authResponse.ExpirySeconds-300) * time.Second,
 	)
 
+	log.Printf(
+		"RefreshTokeN: Refreshed access token for %s", authResponse.UserID,
+	)
 	return MonzoAccessAndRefreshTokens{
 		AccessToken:  authResponse.AccessToken,
 		RefreshToken: authResponse.RefreshToken,

--- a/monzo_api.go
+++ b/monzo_api.go
@@ -28,6 +28,8 @@ func GetUserIdentity(accessToken string) (MonzoCallerIdentity, error) {
 	log.Print("GetUserIdentity: Requesting: /ping/whoami")
 	resp, err := req.Send()
 
+	IncMonzoAPIResponseCode("/ping/whoami", resp.StatusCode)
+
 	if err != nil {
 		log.Printf("GetUserIdentity: Encountered error: /ping/whoami => %s", err)
 		return callerID, err
@@ -50,6 +52,8 @@ func ListAccounts(accessToken string) ([]MonzoAccount, error) {
 	req.Path("/accounts")
 	log.Print("ListAccounts: Requesting: /accounts")
 	resp, err := req.Send()
+
+	IncMonzoAPIResponseCode("/accounts", resp.StatusCode)
 
 	if err != nil {
 		log.Printf("ListAccounts: Encountered error: /accounts => %s", err)
@@ -78,6 +82,8 @@ func ListPots(accessToken string) ([]MonzoPot, error) {
 	log.Print("ListPots: Requesting: /pots")
 	resp, err := req.Send()
 
+	IncMonzoAPIResponseCode("/pots", resp.StatusCode)
+
 	if err != nil {
 		log.Printf("ListPots: Encountered error: /pots => %s", err)
 		return pots, err
@@ -104,6 +110,8 @@ func GetBalance(accessToken string, accountID MonzoAccountID) (MonzoBalance, err
 	log.Printf("GetBalance: Requesting: /balance?account_id=%s", accountID)
 	resp, err := req.Send()
 
+	IncMonzoAPIResponseCode("/balance", resp.StatusCode)
+
 	if err != nil {
 		log.Printf("GetBalance: Encountered error: /pots => %s", err)
 		return balance, err
@@ -128,6 +136,10 @@ func RefreshToken(clientId string, clientSecret string, accessToken string, refr
 	req.AddQuery("client_secret", clientSecret)
 	log.Printf("RefreshToken: Requesting: /oauth2/token")
 	resp, err := req.Send()
+
+	IncMonzoAPIResponseCode(
+		"/oauth2/token?grant_type=refresh_token", resp.StatusCode,
+	)
 
 	if err != nil {
 		log.Printf(

--- a/monzo_api.go
+++ b/monzo_api.go
@@ -165,7 +165,7 @@ func RefreshToken(clientId string, clientSecret string, accessToken string, refr
 	)
 
 	log.Printf(
-		"RefreshTokeN: Refreshed access token for %s", authResponse.UserID,
+		"RefreshToken: Refreshed access token for %s", authResponse.UserID,
 	)
 	return MonzoAccessAndRefreshTokens{
 		AccessToken:  authResponse.AccessToken,

--- a/monzo_api.go
+++ b/monzo_api.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"log"
+	"time"
 
 	"github.com/h2non/gentleman"
 )
@@ -138,8 +139,14 @@ func RefreshToken(clientId string, clientSecret string, accessToken string, refr
 		return returnTokens, err
 	}
 
-	returnTokens.AccessToken = authResponse.AccessToken
-	returnTokens.RefreshToken = authResponse.RefreshToken
+	expiryTime := time.Now().Add(
+		time.Duration(authResponse.ExpirySeconds-300) * time.Second,
+	)
 
-	return returnTokens, nil
+	return MonzoAccessAndRefreshTokens{
+		AccessToken:  authResponse.AccessToken,
+		RefreshToken: authResponse.RefreshToken,
+		UserID:       authResponse.UserID,
+		ExpiryTime:   expiryTime,
+	}, nil
 }

--- a/monzo_collector.go
+++ b/monzo_collector.go
@@ -12,12 +12,12 @@ type MonzoCollector struct {
 }
 
 func (m *MonzoCollector) Stop() {
-	log.Println("Stopping MonzoCollector")
+	log.Println("Stop: Stopping MonzoCollector")
 	m.stop <- true
 }
 
 func (m *MonzoCollector) Serve() {
-	log.Println("Starting MonzoCollector")
+	log.Println("Serve: Starting MonzoCollector")
 	for {
 		select {
 		case <-m.stop:

--- a/monzo_collector.go
+++ b/monzo_collector.go
@@ -6,7 +6,7 @@ import (
 )
 
 type MonzoCollector struct {
-	accessTokenGetter func() ([]string, error)
+	usingAccessTokens func(func([]string) error) error
 	duration          time.Duration
 	stop              chan bool
 }
@@ -21,66 +21,109 @@ func (m *MonzoCollector) Serve() {
 	for {
 		select {
 		case <-m.stop:
+			log.Println("Serve: Stopping")
 			m.stop <- true
+			log.Println("Serve: Stopped")
 			return
 		default:
-			CollectAllMetrics(m.accessTokenGetter)
+			log.Println("Serve: Starting metric collection")
+			err := m.usingAccessTokens(CollectAllMetrics)
+			log.Println("Serve: Finished metric collection")
+
+			if err != nil {
+				log.Printf("Serve: Encountered error collecting metrics => %s", err)
+			}
+
+			log.Println("Serve: Sleeping")
 			time.Sleep(m.duration)
 		}
 	}
 }
 
-func CollectAllMetrics(
-	accessTokensGetter func() ([]string, error),
-) {
+func CollectAllMetrics(accessTokens []string) error {
+	log.Printf("CollectAllMetrics: Starting for %d tokens", len(accessTokens))
 
-	accessTokens, err := accessTokensGetter()
-
-	if err != nil {
-		panic(err)
-	}
-
-	for _, token := range accessTokens {
+	for i, token := range accessTokens {
+		log.Printf("CollectAllMetrics: Doing token %d of %d",
+			i+1, len(accessTokens),
+		)
 
 		identity, err := GetUserIdentity(token)
-
 		if err != nil {
-			panic(err)
+			return err
 		}
 
-		CollectAccountMetrics(token, identity)
-		CollectPotMetrics(token, identity)
+		err = CollectAccountMetrics(token, identity)
+		if err != nil {
+			return err
+		}
+
+		err = CollectPotMetrics(token, identity)
+		if err != nil {
+			return err
+		}
+
+		log.Printf("CollectAllMetrics: Done for user => %s", identity.UserID)
 	}
+
+	log.Printf("CollectAllMetrics: Done %d tokens", len(accessTokens))
+	return nil
 }
 
-func CollectAccountMetrics(accessToken string, identity MonzoCallerIdentity) {
+func CollectAccountMetrics(accessToken string, identity MonzoCallerIdentity) error {
+	log.Printf("CollectAccountMetrics: Starting user %s", identity.UserID)
+
 	accounts, err := ListAccounts(accessToken)
 
 	if err != nil {
-		panic(err)
+		log.Printf(
+			"CollectAccountMetrics: Encountered error listing accounts for user %s => %s",
+			identity.UserID, err,
+		)
+		return err
 	}
 
 	for _, account := range accounts {
+		log.Printf(
+			"CollectAccountMetrics: Getting balance for user %s", identity.UserID,
+		)
+
 		balance, err := GetBalance(accessToken, account.ID)
 
 		if err != nil {
-			panic(err)
+			log.Printf(
+				"CollectAccountMetrics: Encountered error getting balance for user %s => %s",
+				identity.UserID, err,
+			)
+			return err
 		}
 
 		SetCurrentBalance(identity.UserID, account.ID, balance.Balance)
 		SetTotalBalance(identity.UserID, account.ID, balance.TotalBalance)
 		SetSpendToday(identity.UserID, account.ID, balance.SpendToday)
 	}
+
+	log.Printf("CollectAccountMetrics: Done user %s", identity.UserID)
+	return nil
 }
 
-func CollectPotMetrics(accessToken string, identity MonzoCallerIdentity) {
+func CollectPotMetrics(accessToken string, identity MonzoCallerIdentity) error {
+	log.Printf("CollectPotMetrics: Starting user %s", identity.UserID)
 	pots, err := ListPots(accessToken)
 
 	if err != nil {
-		panic(err)
+		log.Printf(
+			"CollectPotMetrics: Encountered error listing pots for user %s => %s",
+			identity.UserID, err,
+		)
+		return err
 	}
 
 	for _, pot := range pots {
 		SetPotBalance(identity.UserID, pot.ID, pot.Name, pot.Balance)
 	}
+
+	log.Printf("CollectPotMetrics: Done user %s", identity.UserID)
+
+	return nil
 }

--- a/monzo_collector.go
+++ b/monzo_collector.go
@@ -53,6 +53,8 @@ func CollectAllMetrics(accessTokens []string) error {
 			return err
 		}
 
+		SetUserLatestCollect(identity.UserID)
+
 		err = CollectAccountMetrics(token, identity)
 		if err != nil {
 			return err

--- a/monzo_metrics.go
+++ b/monzo_metrics.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -35,6 +37,14 @@ var (
 			Help: "Shows the individual pot balance",
 		},
 		[]string{"user_id", "pot_id", "pot_name"},
+	)
+
+	accessTokenExpiryMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "monzo_access_token_expiry",
+			Help: "Shows the unix timestamp expiry for the access token",
+		},
+		[]string{"user_id"},
 	)
 )
 
@@ -97,4 +107,15 @@ func SetPotBalance(
 			"pot_name": potName,
 		},
 	).Set(float64(balance))
+}
+
+func SetAccessTokenExpiry(
+	userID MonzoUserID,
+	expiryTime time.Time,
+) {
+	accessTokenExpiryMetric.With(
+		prometheus.Labels{
+			"user_id": string(userID),
+		},
+	).Set(float64(expiryTime.Unix()))
 }

--- a/monzo_metrics.go
+++ b/monzo_metrics.go
@@ -39,6 +39,14 @@ var (
 		[]string{"user_id", "pot_id", "pot_name"},
 	)
 
+	userLatestCollectMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "monzo_user_latest_collect",
+			Help: "Shows the unix timestamp expiry for most recent data collection",
+		},
+		[]string{"user_id"},
+	)
+
 	accessTokenExpiryMetric = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "monzo_access_token_expiry",
@@ -53,6 +61,7 @@ func RegisterCustomMetrics() {
 	prometheus.MustRegister(totalBalanceMetric)
 	prometheus.MustRegister(spendTodayMetric)
 	prometheus.MustRegister(potBalanceMetric)
+	prometheus.MustRegister(userLatestCollectMetric)
 	prometheus.MustRegister(accessTokenExpiryMetric)
 }
 
@@ -108,6 +117,14 @@ func SetPotBalance(
 			"pot_name": potName,
 		},
 	).Set(float64(balance))
+}
+
+func SetUserLatestCollect(userID MonzoUserID) {
+	userLatestCollectMetric.With(
+		prometheus.Labels{
+			"user_id": string(userID),
+		},
+	).Set(float64(time.Now().Unix()))
 }
 
 func SetAccessTokenExpiry(

--- a/monzo_metrics.go
+++ b/monzo_metrics.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -70,6 +71,11 @@ func SetCurrentBalance(
 	accountID MonzoAccountID,
 	balance int64,
 ) {
+	log.Printf(
+		"Setting monzo_current_balance for user %s for account %s to %d",
+		userID, accountID, balance,
+	)
+
 	currentBalanceMetric.With(
 		prometheus.Labels{
 			"user_id":    string(userID),
@@ -83,6 +89,11 @@ func SetTotalBalance(
 	accountID MonzoAccountID,
 	balance int64,
 ) {
+	log.Printf(
+		"Setting monzo_total_balance for user %s for account %s to %d",
+		userID, accountID, balance,
+	)
+
 	totalBalanceMetric.With(
 		prometheus.Labels{
 			"user_id":    string(userID),
@@ -96,6 +107,11 @@ func SetSpendToday(
 	accountID MonzoAccountID,
 	spend int64,
 ) {
+	log.Printf(
+		"Setting monzo_spend_today for user %s for account %s to %d",
+		userID, accountID, spend,
+	)
+
 	spendTodayMetric.With(
 		prometheus.Labels{
 			"user_id":    string(userID),
@@ -110,6 +126,11 @@ func SetPotBalance(
 	potName string,
 	balance int64,
 ) {
+	log.Printf(
+		"Setting monzo_pot_balance for user %s for pot %s to %d",
+		userID, potID, balance,
+	)
+
 	potBalanceMetric.With(
 		prometheus.Labels{
 			"user_id":  string(userID),
@@ -120,17 +141,29 @@ func SetPotBalance(
 }
 
 func SetUserLatestCollect(userID MonzoUserID) {
+	timestamp := time.Now().Unix()
+
+	log.Printf(
+		"Setting monzo_user_latest_collect for user %s to %d",
+		userID, timestamp,
+	)
+
 	userLatestCollectMetric.With(
 		prometheus.Labels{
 			"user_id": string(userID),
 		},
-	).Set(float64(time.Now().Unix()))
+	).Set(float64(timestamp))
 }
 
 func SetAccessTokenExpiry(
 	userID MonzoUserID,
 	expiryTime time.Time,
 ) {
+	log.Printf(
+		"Setting monzo_access_token_expiry for user %s to %d",
+		userID, expiryTime.Unix(),
+	)
+
 	accessTokenExpiryMetric.With(
 		prometheus.Labels{
 			"user_id": string(userID),

--- a/monzo_metrics.go
+++ b/monzo_metrics.go
@@ -53,6 +53,7 @@ func RegisterCustomMetrics() {
 	prometheus.MustRegister(totalBalanceMetric)
 	prometheus.MustRegister(spendTodayMetric)
 	prometheus.MustRegister(potBalanceMetric)
+	prometheus.MustRegister(accessTokenExpiryMetric)
 }
 
 func SetCurrentBalance(

--- a/monzo_metrics.go
+++ b/monzo_metrics.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"time"
 
@@ -55,6 +56,14 @@ var (
 		},
 		[]string{"user_id"},
 	)
+
+	monzoAPIResponseCodeMetric = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "monzo_api_response_code",
+			Help: "Shows the response codes per endpoint from the Monzo API",
+		},
+		[]string{"response_code", "endpoint"},
+	)
 )
 
 func RegisterCustomMetrics() {
@@ -64,6 +73,7 @@ func RegisterCustomMetrics() {
 	prometheus.MustRegister(potBalanceMetric)
 	prometheus.MustRegister(userLatestCollectMetric)
 	prometheus.MustRegister(accessTokenExpiryMetric)
+	prometheus.MustRegister(monzoAPIResponseCodeMetric)
 }
 
 func SetCurrentBalance(
@@ -169,4 +179,21 @@ func SetAccessTokenExpiry(
 			"user_id": string(userID),
 		},
 	).Set(float64(expiryTime.Unix()))
+}
+
+func IncMonzoAPIResponseCode(
+	endpoint string,
+	responseCode int,
+) {
+	log.Printf(
+		"Incrementing monzo_api_response_code %d for endpoint %s",
+		responseCode, endpoint,
+	)
+
+	monzoAPIResponseCodeMetric.With(
+		prometheus.Labels{
+			"endpoint":      endpoint,
+			"response_code": fmt.Sprintf("%d", responseCode),
+		},
+	).Inc()
 }

--- a/monzo_oauth.go
+++ b/monzo_oauth.go
@@ -201,7 +201,7 @@ func (m *MonzoOAuthClient) UsingAccessTokens(fun func([]string) error) error {
 		)
 	}
 
-	log.Println(
+	log.Printf(
 		"UsingAccessTokens: Calling func with %d access tokens",
 		len(accessTokens),
 	)

--- a/monzo_oauth.go
+++ b/monzo_oauth.go
@@ -200,12 +200,10 @@ func (m *MonzoOAuthClient) GetAccessTokens() ([]string, error) {
 }
 
 func (m *MonzoOAuthClient) listen(port int) func() ([]string, error) {
-	tokensBox := ConcurrentMonzoTokensBox{
+	m.TokensBox = ConcurrentMonzoTokensBox{
 		Lock:   sync.Mutex{},
 		Tokens: make([]MonzoAccessAndRefreshTokens, 0),
 	}
-
-	m.TokensBox = tokensBox
 
 	server := &http.Server{
 		Addr:    fmt.Sprintf(":%d", port),

--- a/monzo_oauth.go
+++ b/monzo_oauth.go
@@ -216,7 +216,7 @@ func (m *MonzoOAuthClient) listen(port int) func() ([]string, error) {
 	return m.GetAccessTokens
 }
 
-func (m *MonzoOAuthClient) RefreshTokens() error {
+func (m *MonzoOAuthClient) RefreshAToken() error {
 	log.Println("Locking TokensBox")
 	m.TokensBox.Lock.Lock()
 

--- a/monzo_oauth.go
+++ b/monzo_oauth.go
@@ -154,6 +154,8 @@ func (m *MonzoOAuthClient) handleJourneyCallback(w http.ResponseWriter, r *http.
 	)
 	log.Println("handleJourneyCallback: Appended to TokensBox")
 
+	SetAccessTokenExpiry(authResponse.UserID, expiryTime)
+
 	w.WriteHeader(http.StatusCreated)
 	w.Write([]byte("201 - Tokens received and accepted"))
 }

--- a/monzo_oauth.go
+++ b/monzo_oauth.go
@@ -52,7 +52,7 @@ func (m *MonzoOAuthClient) handleJourneyStart(w http.ResponseWriter, r *http.Req
 	}, "&")
 	monzoAuthURI := fmt.Sprintf("https://auth.monzo.com?%s", query)
 
-	log.Printf("Redirecting user to %s\n", monzoAuthURI)
+	log.Printf("handleJourneyStart: Redirecting user to %s\n", monzoAuthURI)
 	http.Redirect(w, r, monzoAuthURI, 302)
 }
 
@@ -106,7 +106,7 @@ func (m *MonzoOAuthClient) handleJourneyCallback(w http.ResponseWriter, r *http.
 	client.URL(authURL)
 	client.Use(multipart.Fields(fields))
 
-	log.Printf("Making POST request to %s\n", authURL)
+	log.Printf("handleJourneyCallback: Making POST request to %s\n", authURL)
 	response, err := client.Request().Method("POST").Send()
 
 	if err != nil {
@@ -117,7 +117,10 @@ func (m *MonzoOAuthClient) handleJourneyCallback(w http.ResponseWriter, r *http.
 		return
 	}
 
-	log.Printf("Response to POST request to %s was %d\n", authURL, response.StatusCode)
+	log.Printf(
+		"handleJourneyCallback: Response to POST request to %s was %d\n",
+		authURL, response.StatusCode,
+	)
 
 	var authResponse MonzoAuthResponse
 	err = json.Unmarshal(response.Bytes(), &authResponse)
@@ -132,8 +135,13 @@ func (m *MonzoOAuthClient) handleJourneyCallback(w http.ResponseWriter, r *http.
 		time.Duration(authResponse.ExpirySeconds-300) * time.Second,
 	)
 
-	log.Println("Locking TokensBox")
+	log.Println("handleJourneyCallback: Locking TokensBox")
 	m.TokensBox.Lock.Lock()
+
+	defer func() {
+		log.Println("handleJourneyCallback: Unlocking TokensBox")
+		m.TokensBox.Lock.Unlock()
+	}()
 
 	m.TokensBox.Tokens = append(
 		m.TokensBox.Tokens,
@@ -144,10 +152,7 @@ func (m *MonzoOAuthClient) handleJourneyCallback(w http.ResponseWriter, r *http.
 			ExpiryTime:   expiryTime,
 		},
 	)
-	log.Println("Appended to TokensBox")
-
-	log.Println("Unlocking TokensBox")
-	m.TokensBox.Lock.Unlock()
+	log.Println("handleJourneyCallback: Appended to TokensBox")
 
 	w.WriteHeader(http.StatusCreated)
 	w.Write([]byte("201 - Tokens received and accepted"))
@@ -162,7 +167,7 @@ func (m *MonzoOAuthClient) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("GET %s\n", path)
+	log.Printf("ServeHTTP: GET %s\n", path)
 
 	if path == START_PATH {
 		m.handleJourneyStart(w, r)
@@ -175,27 +180,27 @@ func (m *MonzoOAuthClient) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusNotFound)
 	w.Write([]byte("404 - Not found"))
-	log.Printf("Served 404 for %s\n", path)
+	log.Printf("ServeHTTP: Served 404 for %s\n", path)
 }
 
 func (m *MonzoOAuthClient) GetAccessTokens() ([]string, error) {
-	log.Println("Getting access tokens")
+	log.Println("GetAccessTokens: Getting access tokens")
 	tokens := make([]string, 0)
 
-	log.Println("Locking TokensBox")
+	log.Println("GetAccessTokens: Locking TokensBox")
 	m.TokensBox.Lock.Lock()
 	defer func() {
-		log.Println("Unlocking TokensBox")
+		log.Println("GetAccessTokens: Unlocking TokensBox")
 		m.TokensBox.Lock.Unlock()
 	}()
 
-	log.Printf("There are %d tokens in the box\n", len(m.TokensBox.Tokens))
+	log.Printf("GetAccessTokens: There are %d tokens in the box\n", len(m.TokensBox.Tokens))
 
 	for _, accessAndRefreshToken := range m.TokensBox.Tokens {
 		tokens = append(tokens, string(accessAndRefreshToken.AccessToken))
 	}
 
-	log.Println("Finished getting access tokens")
+	log.Println("GetAccessTokens: Finished getting access tokens")
 	return tokens, nil
 }
 
@@ -215,18 +220,19 @@ func (m *MonzoOAuthClient) listen(port int) func() ([]string, error) {
 }
 
 func (m *MonzoOAuthClient) RefreshAToken() error {
-	log.Println("Locking TokensBox")
+	log.Println("RefreshAToken: Locking TokensBox")
 	m.TokensBox.Lock.Lock()
+	log.Println("RefreshAToken: Locked TokensBox")
 
 	tokens := m.TokensBox.Tokens
 
 	defer func() {
-		log.Println("Unlocking TokensBox")
+		log.Println("RefreshAToken: Unlocking TokensBox")
 		m.TokensBox.Lock.Unlock()
 	}()
 
 	if len(tokens) == 0 {
-		log.Println("No tokens to refresh. Done")
+		log.Println("RefreshAToken: No tokens to refresh. Done")
 		return nil
 	}
 
@@ -235,7 +241,7 @@ func (m *MonzoOAuthClient) RefreshAToken() error {
 
 	doWeNeedToRefresh := true // FIXME
 	if doWeNeedToRefresh {
-		log.Printf("Refreshing token for user %s", headToken.UserID)
+		log.Printf("RefreshAToken: Refreshing token for user %s", headToken.UserID)
 
 		refreshedToken, err := RefreshToken(
 			m.MonzoOAuthClientID, m.MonzoOAuthClientSecret,
@@ -244,17 +250,18 @@ func (m *MonzoOAuthClient) RefreshAToken() error {
 
 		if err != nil {
 			return fmt.Errorf(
-				"Encountered error refreshing token for user %s => %s",
+				"RefreshAToken: Encountered error refreshing token for user %s => %s",
 				headToken.UserID, err,
 			)
 		}
 
 		headToken = refreshedToken
-		log.Printf("Refreshed token for user %s", headToken.UserID)
+		log.Printf("RefreshAToken: Refreshed token for user %s", headToken.UserID)
 
 		SetAccessTokenExpiry(headToken.UserID, headToken.ExpiryTime)
 	}
 
 	m.TokensBox.Tokens = append(tailTokens, headToken)
+	log.Println("RefreshAToken: Rotated tokens")
 	return nil
 }

--- a/monzo_types.go
+++ b/monzo_types.go
@@ -58,12 +58,15 @@ type MonzoCallerIdentity struct {
 type MonzoAuthResponse struct {
 	AccessToken   MonzoAccessToken  `json:"access_token"`
 	RefreshToken  MonzoRefreshToken `json:"refresh_token"`
+	UserID        MonzoUserID       `json:"user_id"`
 	ExpirySeconds int64             `json:"expires_in"`
 }
 
 type MonzoAccessAndRefreshTokens struct {
 	AccessToken  MonzoAccessToken
 	RefreshToken MonzoRefreshToken
+	UserID       MonzoUserID
+	ExpiryTime   time.Time
 }
 
 type ConcurrentMonzoTokensBox struct {

--- a/monzo_types.go
+++ b/monzo_types.go
@@ -59,7 +59,7 @@ type MonzoAuthResponse struct {
 	AccessToken   MonzoAccessToken  `json:"access_token"`
 	RefreshToken  MonzoRefreshToken `json:"refresh_token"`
 	UserID        MonzoUserID       `json:"user_id"`
-	ExpirySeconds int64             `json:"expires_in"`
+	ExpirySeconds float64           `json:"expires_in"`
 }
 
 type MonzoAccessAndRefreshTokens struct {


### PR DESCRIPTION
What
---

- Implement OAuth refreshing
- Refactor how we use the mutex to scrape metrics whilst safely being able to refresh them add append to them (not done yet)
- Emit metric `monzo_user_latest_collect` to help observe when the exporter is scraping
- Emit metric `monzo_access_token_expiry` to help observe when the exporter is refreshing users