### PR TITLE
Fix params for /pots API call

### DIFF
--- a/monzo_api.go
+++ b/monzo_api.go
@@ -76,11 +76,12 @@ func ListAccounts(accessToken string) ([]MonzoAccount, error) {
 	return accounts, nil
 }
 
-func ListPots(accessToken string) ([]MonzoPot, error) {
+func ListPots(accessToken string, accountID MonzoAccountID) ([]MonzoPot, error) {
 	var pots []MonzoPot
 
 	req := MonzoClient(accessToken)
 	req.Path("/pots")
+	req.AddQuery("current_account_id", string(accountID))
 	log.Print("ListPots: Requesting: /pots")
 	resp, err := req.Send()
 

--- a/monzo_collector.go
+++ b/monzo_collector.go
@@ -154,21 +154,34 @@ func CollectAccountMetrics(accessToken string, identity MonzoCallerIdentity) err
 
 func CollectPotMetrics(accessToken string, identity MonzoCallerIdentity) error {
 	log.Printf("CollectPotMetrics: Starting user %s", identity.UserID)
-	pots, err := ListPots(accessToken)
+
+	accounts, err := ListAccounts(accessToken)
 
 	if err != nil {
 		log.Printf(
-			"CollectPotMetrics: Encountered error listing pots for user %s => %s",
+			"CollectAccountMetrics: Encountered error listing accounts for user %s => %s",
 			identity.UserID, err,
 		)
 		return err
 	}
 
-	for _, pot := range pots {
-		SetPotBalance(identity.UserID, pot.ID, pot.Name, pot.Balance)
-	}
+	for _, account := range accounts {
+		pots, err := ListPots(accessToken, account.ID)
 
-	log.Printf("CollectPotMetrics: Done user %s", identity.UserID)
+		if err != nil {
+			log.Printf(
+				"CollectPotMetrics: Encountered error listing pots for user %s => %s",
+				identity.UserID, err,
+			)
+			return err
+		}
+
+		for _, pot := range pots {
+			SetPotBalance(identity.UserID, pot.ID, pot.Name, pot.Balance)
+		}
+
+		log.Printf("CollectPotMetrics: Done user %s", identity.UserID)
+	}
 
 	return nil
 }


### PR DESCRIPTION
- I built my own Monzo account status thingy, then I was reminded that this existed. Upon trying to use this Prometheus exporter (with a Playground API token), I got a 400 response when trying to get metrics for Pots:

```
2020/07/16 22:23:53 ListPots: Requesting: /pots
2020/07/16 22:23:53 Incrementing monzo_api_response_code 400 for endpoint /pots
2020/07/16 22:23:53 ListPots Finished: /pots
```

- The [Monzo API docs for the `/pots` endpoint](https://docs.monzo.com/#pots) specify an AccountID parameter named `current_account_id`. With these changes, I get a 200 API response and I can see my individual pots' balances in Prometheus:

```
2020/07/16 22:37:15 ListPots: Requesting: /pots
2020/07/16 22:37:16 Incrementing monzo_api_response_code 200 for endpoint /pots
2020/07/16 22:37:16 ListPots Finished: /pots
```

- I'm still not particularly fluent in Go, so you'll probably see some improvements, but. :-) Also it's probably useful to review this with `?w=1` on the end of the GitHub URL.
